### PR TITLE
Don't blacklist classes; check output. Fixes #9

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,16 @@ export default function ({ Plugin, types: t }) {
         }
       }
     },
+    ClassProperty(node, parent, scope) {
+      if (node.key.name === 'propTypes') {
+        const className = scope.block.id.name;
+        const binding = this.scope.getBinding(className);
+        const superClass = binding.path.get('superClass');
+        if (superClass.matchesPattern('React.Component') || superClass.matchesPattern('Component')) {
+          this.dangerouslyRemove();
+        }
+      }
+    },
     AssignmentExpression(node) {
       if (node.left.computed || node.left.property.name !== 'propTypes') {
         return;

--- a/test/fixtures/es-class-assign-property/expected.js
+++ b/test/fixtures/es-class-assign-property/expected.js
@@ -1,5 +1,19 @@
 "use strict";
 
-class Foo extends React.Component {
-  render() {}
-}
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo = (function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    _React$Component.apply(this, arguments);
+  }
+
+  Foo.prototype.render = function render() {};
+
+  return Foo;
+})(React.Component);

--- a/test/fixtures/es-class-static-property/expected.js
+++ b/test/fixtures/es-class-static-property/expected.js
@@ -1,6 +1,19 @@
 "use strict";
 
-class Foo extends React.Component {
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  render() {}
-}
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo = (function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    _React$Component.apply(this, arguments);
+  }
+
+  Foo.prototype.render = function render() {};
+
+  return Foo;
+})(React.Component);

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,6 @@ describe('remove react propTypes', () => {
       const fixtureDir = path.join(fixturesDir, caseName);
       const actual = babel.transformFileSync(path.join(fixtureDir, 'actual.js'), {
         stage: 0,
-        blacklist: ['es6.classes'],
         plugins: [
           reactPlugin
         ]


### PR DESCRIPTION
We have to check the rendered output to be sure it's gone. Was finding that after the class transformation the propTypes will still making it through.

Fixes #9
